### PR TITLE
add extract from kaggle and save to duckDB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ openai = "^0.28.0"
 ipywidgets = "^8.1.1"
 chainlit = "^0.7.0"
 pandas = "2.0.3"
+kaggle = "^1.5.16"
 
 
 [build-system]

--- a/src/app/faqpipeline.py
+++ b/src/app/faqpipeline.py
@@ -1,0 +1,94 @@
+import os
+from dotenv import load_dotenv
+import pandas as pd
+from haystack.nodes import EmbeddingRetriever
+from haystack.document_stores import InMemoryDocumentStore
+from haystack.pipelines import FAQPipeline
+from haystack.utils import print_answers
+
+prepared_dir = '../data/prepared'
+prepared_recipe_file_name = 'recipes_prepared.csv'
+
+def load_prepared_data(start_record,end_record):
+    """
+    Load data from file preprocessed initially
+    Args:
+        start_record: start records to load in case large files
+        end_record: last record to load
+    Returns:
+        Dataframe: Panda Dataframe with columns question, answer, etc..        
+    """
+    prepared_recipe_file = prepared_dir+'/'+ prepared_recipe_file_name
+    print('prepared file: ',prepared_recipe_file)
+    print('loading data...')
+    return pd.read_csv(prepared_recipe_file,index_col=False)[start_record:end_record]
+
+
+def initialize_document_store():
+    """
+    Initialize a In Memory document store and retriever.
+
+    Args:
+        documents (List[Document]): List of documents to be stored in the document store.
+
+    Returns:
+        document_store (InMemoryDocumentStore): In Memory document store.
+        retriever (EmbeddingRetriever): Embedding retriever.
+    """
+    
+    # Initialize document store
+    document_store = InMemoryDocumentStore()
+
+    retriever = EmbeddingRetriever(
+        document_store=document_store,
+        embedding_model="sentence-transformers/all-MiniLM-L6-v2",
+        use_gpu=False,
+        scale_score=False,)
+    
+
+    return document_store, retriever 
+
+def add_embedding_to_data(df, retriever):
+    """
+    Add embedded data to dataframe
+
+    Returns:
+        Dataframe: Panda Dataframe with columns embedding 
+        and column question renamed as context. 
+    """
+    questions = list(df["question"].values)
+    df["embedding"] = retriever.embed_queries(queries=questions).tolist()
+    df = df.rename(columns={"question": "content"})
+    return df
+
+def load_document_store(document_store,df):
+    """Load data to document store"""
+    docs_to_index = df.to_dict(orient="records")
+    document_store.delete_documents()
+    document_store.write_documents(docs_to_index)
+    print('document store loaded')
+    return document_store
+
+if __name__=="__main__":
+
+    load_dotenv("../.env")
+    openai_key = os.getenv("OPENAI_API_KEY")
+
+    query = input("Ask a question: ")
+
+    
+    document_store, retriever = initialize_document_store()
+
+    raw_df = load_prepared_data(0,100)
+    df = add_embedding_to_data(raw_df,retriever)
+
+    document_store = load_document_store(document_store, df)
+
+    pipe = FAQPipeline(retriever=retriever)
+
+    # Run any question and change top_k to see more or less answers
+    result = pipe.run(query=query, params={"Retriever": {"top_k": 1}})
+    ##TODO add prompt and llm here
+    
+    #print(result['answers'][0].answer)
+    print(result)

--- a/src/app/prototype_indx_inmemory_ini.ipynb
+++ b/src/app/prototype_indx_inmemory_ini.ipynb
@@ -1,0 +1,327 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#####  Test haystack retrieval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from haystack.nodes import EmbeddingRetriever\n",
+    "from haystack.document_stores import InMemoryDocumentStore\n",
+    "from haystack.pipelines import FAQPipeline\n",
+    "from haystack.utils import print_answers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prepared_dir = '../data/prepared'\n",
+    "prepared_recipe_file_name = 'recipes_prepared.csv'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_prepared_data():\n",
+    "    prepared_recipe_file = prepared_dir+'/'+ prepared_recipe_file_name\n",
+    "    print('prepared file: ',prepared_recipe_file)\n",
+    "    print('loading data...')\n",
+    "    return pd.read_csv(prepared_recipe_file,index_col=False) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def initialize_document_store():\n",
+    "    \"\"\"\n",
+    "    Initialize a In Memory document store and retriever.\n",
+    "\n",
+    "    Args:\n",
+    "        documents (List[Document]): List of documents to be stored in the document store.\n",
+    "\n",
+    "    Returns:\n",
+    "        document_store (InMemoryDocumentStore): In Memory document store.\n",
+    "        retriever (EmbeddingRetriever): Embedding retriever.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    # Initialize document store\n",
+    "    document_store = InMemoryDocumentStore()\n",
+    "\n",
+    "    retriever = EmbeddingRetriever(\n",
+    "        document_store=document_store,\n",
+    "        embedding_model=\"sentence-transformers/all-MiniLM-L6-v2\",\n",
+    "        use_gpu=False,\n",
+    "        scale_score=False,)\n",
+    "    \n",
+    "\n",
+    "    return document_store, retriever"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def add_embedding_to_data(df, retriever):\n",
+    "    questions = list(df[\"question\"].values)\n",
+    "    df[\"embedding\"] = retriever.embed_queries(queries=questions).tolist()\n",
+    "    df = df.rename(columns={\"question\": \"content\"})\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_document_store(document_store,df):\n",
+    "    docs_to_index = df.to_dict(orient=\"records\")\n",
+    "    document_store.delete_documents()\n",
+    "    document_store.write_documents(docs_to_index)\n",
+    "    print('document store loaded')\n",
+    "    return document_store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prepared file:  ../data/prepared/recipes_prepared.csv\n",
+      "loading data...\n"
+     ]
+    }
+   ],
+   "source": [
+    "raw_df = load_prepared_data()\n",
+    "#raw_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\workspace\\hacktoberfest\\.venv\\Lib\\site-packages\\torch\\_utils.py:776: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()\n",
+      "  return self.fget.__get__(instance, owner)()\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "document_store, retriever = initialize_document_store()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7fb7055d7ea44530a6f0199d88929d78",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/32 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\Eva\\AppData\\Local\\Temp\\ipykernel_32904\\4095768192.py:3: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  df[\"embedding\"] = retriever.embed_queries(queries=questions).tolist()\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = add_embedding_to_data(raw_df,retriever)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "document store loaded\n"
+     ]
+    }
+   ],
+   "source": [
+    "document_store = load_document_store(document_store, df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = FAQPipeline(retriever=retriever)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f92ca39c6d5e49038c9b5758775bee78",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'Query: ingredients eggs, cheese, chicken'\n",
+      "'Answers:'\n",
+      "[   <Answer {'answer': 'recommendation: i call this ', 'type': 'other', 'score': 0.6540048641089629, 'context': 'recommendation: i call this ', 'offsets_in_document': None, 'offsets_in_context': [{'start': 0, 'end': 28}], 'document_ids': ['59632'], 'meta': {'name': 'kitchen sink  egg bake', 'minutes': 70, 'contributor_id': 79219, 'submitted': '2003-04-14', 'tags': \"['weeknight', 'time-to-make', 'course', 'main-ingredient', 'preparation', 'occasion', 'omelets-and-frittatas', 'breakfast', 'eggs-dairy', 'cheese', 'eggs', 'dietary', 'low-carb', 'inexpensive', 'low-in-something', 'brunch', '4-hours-or-less']\", 'nutrition': '[794.2, 109.0, 9.0, 30.0, 59.0, 153.0, 3.0]', 'n_steps': 14, 'steps': \"['preheat oven to 325', 'thaw spinach , and squeeze out as much moisture as possible', 'beat the eggs in medium bowl', 'stir in the cottage cheese , grated cheese , spinach and seasonings', 'stir until mixed thoroughly', 'lightly spray glass 13x9 pan w / olive oil or pam', 'distribute meat / chicken / ham evenly over bottom of pan', 'pour cottage cheese mixture over meat', 'push w / spatula to distribute evenly', 'top with extra grated cheese if desired', 'sprinkle top w / toasted wheat germ', 'bake 45-50 minutes , until set and slightly brown at edges', 'let sit a few minutes out of oven before serving', 'serve hot or at room temperature']\", 'description': 'i call this ', 'ingredients': \"['eggs', 'cottage cheese', 'cheese', 'frozen chopped spinach', 'beef', 'salt', 'pepper', 'herbs', 'spices', 'olive oil flavored cooking spray', 'toasted wheat germ']\", 'n_ingredients': 11, 'answer': 'recommendation: i call this ', 'query': \"name: kitchen sink  egg bake\\ndescription: i call this \\ningredients: ['eggs', 'cottage cheese', 'cheese', 'frozen chopped spinach', 'beef', 'salt', 'pepper', 'herbs', 'spices', 'olive oil flavored cooking spray', 'toasted wheat germ']\"}}>]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run any question and change top_k to see more or less answers\n",
+    "prediction = pipe.run(query=\"ingredients eggs, cheese, chicken\", params={\"Retriever\": {\"top_k\": 1}})\n",
+    "\n",
+    "print_answers(prediction, details=\"all\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a7af7271b4004ec1a5f6e5fda020d4a3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Batches:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'Query: ingredients chicken, ham, cheese'\n",
+      "'Answers:'\n",
+      "[   {   'answer': 'recommendation: this is a very easy recipe given to me '\n",
+      "                  'years ago by a great friend.',\n",
+      "        'context': 'recommendation: this is a very easy recipe given to me '\n",
+      "                   'years ago by a great friend.',\n",
+      "        'score': 0.6234360379356012}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "\n",
+    "prediction = pipe.run(query=\"ingredients chicken, ham, cheese\", params={\"Retriever\": {\"top_k\": 1}})\n",
+    "\n",
+    "print_answers(prediction, details=\"medium\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/etl/extract-eva.py
+++ b/src/etl/extract-eva.py
@@ -1,0 +1,49 @@
+# + tags=["parameters"]
+# declare a list tasks whose products you want to use as inputs
+upstream = None
+
+
+# +
+import os
+import pandas as pd
+import duckdb
+import kaggle
+
+# +
+dataset = 'shuyangli94/food-com-recipes-and-user-interactions'
+extract_dir = './src/data/raw'
+raw_recipe_file_name = 'RAW_recipes.csv'
+
+# +
+def download_data_from_kaggle():
+    """Download data from kaggle""" 
+    raw_recipe_file = os.path.join(extract_dir, raw_recipe_file_name) 
+    print(raw_recipe_file)      
+    if not os.path.isfile(raw_recipe_file):        
+       print("Dataset not found, using kaggle-api tool for download")
+       # Download the data
+       kaggle.api.authenticate()
+       kaggle.api.dataset_download_files(dataset, path=extract_dir, unzip=True)
+    return pd.read_csv(raw_recipe_file)
+
+# +
+# write a function that saves a dataframe to duckdb
+def save_to_duckdb(df, table_name, db_path):
+    """Save dataframe to duckdb"""
+    conn = duckdb.connect(db_path)
+    conn.register('df', df)
+    conn.execute(f"CREATE TABLE {table_name} AS SELECT * FROM df")
+    conn.close()
+
+# +
+if __name__ == "__main__":
+
+    df = download_data_from_kaggle()
+    if not df.empty:       
+       # Save to duckdb
+       db_path = "data.duckdb"
+       table_name = "RAW_recipes"
+       save_to_duckdb(df, table_name, db_path)
+       print('Saved RAW_recipes to duckdb.') 
+    else:
+       print('DataFrame is empty!') 

--- a/src/etl/preprocess-ini-eva.py
+++ b/src/etl/preprocess-ini-eva.py
@@ -1,0 +1,64 @@
+# + tags=["parameters"]
+# declare a list tasks whose products you want to use as inputs
+upstream = None
+
+
+# +
+import os
+import pandas as pd
+
+# +
+extract_dir = './src/data/raw'
+prepared_dir = './src/data/prepared'
+raw_recipe_file_name = 'RAW_recipes.csv'
+prepared_recipe_file_name = 'recipes_prepared.csv'
+
+# +
+def prep_question(row):
+    name = row['name']
+    description = row['description']
+    ingredients = row['ingredients']
+    recipe =  f"name: {name}\ndescription: {description}\ningredients: {ingredients}"
+    return recipe
+
+# +
+def prep_answer(row):    
+    description = row['description']    
+    recipe =  f"recommendation: {description}"
+    return recipe
+
+# +
+# prepare df with extra columns
+def prepare_df():
+    """Prepare df with add columns for question/answer""" 
+    raw_recipe_file = os.path.join(extract_dir, raw_recipe_file_name) 
+    print(raw_recipe_file)      
+    if not os.path.isfile(raw_recipe_file):        
+       print(f"File not found: {raw_recipe_file}")
+       return df.empty
+    raw_df = pd.read_csv(raw_recipe_file)
+    raw_df['question'] = raw_df.apply(prep_question, axis=1)
+    raw_df['answer'] = raw_df.apply(prep_answer, axis=1)
+    return raw_df
+
+# +
+# write a function that saves a dataframe to duckdb
+def save_prepared(df):
+    """Save prepared file to folder"""
+    #TODO: use DuckDB as storage instead 
+    if not os.path.exists(prepared_dir):
+        os.makedirs(prepared_dir)
+        
+    preprocessed_file = f'{prepared_dir}/{prepared_recipe_file_name}'
+    print('Preprocessed file: {preprocessed_file}')   
+    df.to_csv(preprocessed_file,index= False)
+
+# +
+if __name__ == "__main__":
+
+    df = prepare_df()
+    if not df.empty:       
+       save_prepared(df)
+       print('Saved to preprocessed folder') 
+    else:
+       print('File is empty!') 


### PR DESCRIPTION
I see overlap between the two extraction scripts, please work together to identify commonalities and differences.

The end goal should be to populate a duckdb file with clean data extracted from the Kaggle website. 

This duckdb file can then be stored on a cloud-based database service.

Applications will be connected to this cloud-based service. 